### PR TITLE
Detect executable filename

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -12,7 +12,7 @@ namespace QNamer
 
             for (int f = 0; f < currentFiles.Length; f++)
             {
-                if (!currentFiles[f].Contains("QNamer.exe"))
+                if (!currentFiles[f].Contains(System.AppDomain.CurrentDomain.FriendlyName))
                     try
                     {
                         Console.WriteLine($"Attempting to rename [{currentFiles[f]}]...");


### PR DESCRIPTION
A fix for the abnormal behavior when the program's renamed from `QNamer.exe`.